### PR TITLE
Add elapsed time function

### DIFF
--- a/sciris/sc_utils.py
+++ b/sciris/sc_utils.py
@@ -170,7 +170,7 @@ def htmlify(string, reverse=False, tostring=False):
 ##############################################################################
 
 __all__ += ['printv', 'blank', 'createcollist', 'objectid', 'objatt', 'objmeth', 'objrepr']
-__all__ += ['prepr', 'pr', 'indent', 'sigfig', 'printarr', 'printdata', 'printvars', 'getdate', 'elapsedtimestr']
+__all__ += ['prepr', 'pr', 'indent', 'sigfig', 'printarr', 'printdata', 'printvars']
 __all__ += ['slacknotification', 'printtologfile', 'colorize']
 
 def printv(string, thisverbose=1, verbose=2, newline=True, indent=True):
@@ -890,10 +890,10 @@ def promotetolist(obj=None, objtype=None, keepnone=False):
 
 
 ##############################################################################
-### MISC. FUNCTIONS
+### TIME/DATE FUNCTIONS
 ##############################################################################
 
-__all__ += ['now', 'tic', 'toc', 'timedsleep', 'percentcomplete', 'checkmem', 'runcommand', 'gitinfo', 'compareversions', 'uniquename', 'importbyname']
+__all__ += ['now', 'getdate', 'elapsedtimestr', 'tic', 'toc', 'timedsleep']
 
 def now(utc=False, die=False, tostring=False, fmt=None):
     ''' Get the current time, optionally in UTC time '''
@@ -1111,6 +1111,22 @@ def timedsleep(delay=None, verbose=True):
                 print('Warning, delay less than elapsed time (%0.1f vs. %0.1f)' % (delay, elapsed))
     return None
 
+
+
+
+
+
+
+
+
+
+
+
+##############################################################################
+### MISC. FUNCTIONS
+##############################################################################
+
+__all__ += ['percentcomplete', 'checkmem', 'runcommand', 'gitinfo', 'compareversions', 'uniquename', 'importbyname']
 
 def percentcomplete(step=None, maxsteps=None, indent=1):
     ''' Display progress '''

--- a/sciris/sc_utils.py
+++ b/sciris/sc_utils.py
@@ -801,7 +801,7 @@ def elapsed_time_str(past_time, max_days=5, short_months=True):
 
         # Check if the time is within the last minute
         if elapsed_time < datetime.timedelta(seconds=60):
-            if elapsed_time.seconds == 1:
+            if elapsed_time.seconds <= 10:
                 time_str = "just now"
             else:
                 time_str = "%d secs ago" % elapsed_time.seconds

--- a/sciris/sc_utils.py
+++ b/sciris/sc_utils.py
@@ -48,7 +48,7 @@ else:
 
 
 # Define the modules being loaded
-__all__ = ['uuid', 'dcp', 'cp', 'pp', 'sha', 'wget', 'htmlify', 'elapsed_time_str']
+__all__ = ['uuid', 'dcp', 'cp', 'pp', 'sha', 'wget', 'htmlify']
 
 
 def uuid(uid=None, which=None, die=False, tostring=False):
@@ -170,7 +170,7 @@ def htmlify(string, reverse=False, tostring=False):
 ##############################################################################
 
 __all__ += ['printv', 'blank', 'createcollist', 'objectid', 'objatt', 'objmeth', 'objrepr']
-__all__ += ['prepr', 'pr', 'indent', 'sigfig', 'printarr', 'printdata', 'printvars', 'getdate']
+__all__ += ['prepr', 'pr', 'indent', 'sigfig', 'printarr', 'printdata', 'printvars', 'getdate', 'elapsedtimestr']
 __all__ += ['slacknotification', 'printtologfile', 'colorize']
 
 def printv(string, thisverbose=1, verbose=2, newline=True, indent=True):
@@ -727,122 +727,8 @@ def colorize(color=None, string=None, output=False, showhelp=False, enable=True)
         try:    print(ansistring) # Content, so print with newline
         except: print(string) # If that fails, just go with plain version
         return None
-    
-# Elapsed time function by Alex Chan
-# https://gist.github.com/alexwlchan/73933442112f5ae431cc
-def print_date(date, incl_year=True, short_months=True):
-    """Prints a datetime object as a full date, stripping off any leading
-    zeroes from the day (strftime() gives the day of the month as a zero-padded
-    decimal number).
-    """
-    # %b/%B are the tokens for abbreviated/full names of months to strftime()
-    if short_months:
-        month_token = '%b'
-    else:
-        month_token = '%B'
 
-    # Get a string from strftime()
-    if incl_year:
-        date_str = date.strftime('%d ' + month_token + ' %Y')
-    else:
-        date_str = date.strftime('%d ' + month_token)
 
-    # There will only ever be at most one leading zero, so check for this and
-    # remove if necessary
-    if date_str[0] == '0':
-        date_str = date_str[1:]
-
-    return date_str
-
-def elapsed_time_str(past_time, max_days=5, short_months=True):
-    """Accepts a datetime object or a string in ISO 8601 format and returns a
-    human-readable string explaining when this time was.
-    The rules are as follows:
-    * If a time is within the last hour, return 'XX minutes'
-    * If a time is within the last 24 hours, return 'XX hours'
-    * If within the last 5 days, return 'XX days'
-    * If in the same year, print the date without the year
-    * If in a different year, print the date with the whole year
-    These can be configured as options.
-    """
-    now_time = datetime.datetime.now()
-
-    #--------------------------------------------------------------------------
-    # If the user passes in a string, try to turn it into a datetime object
-    # before continuing
-    #--------------------------------------------------------------------------
-    if isinstance(past_time, str):
-        try:
-            past_time = datetime.datetime.strptime(past_time, "%Y-%m-%dT%H:%M:%S.%fZ")
-        except ValueError:
-            raise ValueError("User supplied string %s is not in ISO 8601 "
-                             "format." % past_time)
-    elif isinstance(past_time, datetime.datetime):
-        pass
-    else:
-        raise ValueError("User-supplied value %s is neither a datetime object "
-                         "nor an ISO 8601 string." % past_time)
-
-    #--------------------------------------------------------------------------
-    # It doesn't make sense to measure time elapsed between now and a future
-    # date, so we'll just print the date
-    #--------------------------------------------------------------------------
-    if past_time > now_time:
-        incl_year = (past_time.year != now_time.year)
-        time_str = print_date(past_time,
-                              incl_year=incl_year,
-                              short_months=short_months)
-
-    #--------------------------------------------------------------------------
-    # Otherwise, start by getting the elapsed time as a datetime object
-    #--------------------------------------------------------------------------
-    else:
-        elapsed_time = now_time - past_time
-
-        # Check if the time is within the last minute
-        if elapsed_time < datetime.timedelta(seconds=60):
-            if elapsed_time.seconds <= 10:
-                time_str = "just now"
-            else:
-                time_str = "%d secs ago" % elapsed_time.seconds
-
-        # Check if the time is within the last hour
-        elif elapsed_time < datetime.timedelta(seconds=60 * 60):
-
-            # We know that seconds > 60, so we can safely round down
-            minutes = elapsed_time.seconds / 60
-            if minutes == 1:
-                time_str = "a minute ago"
-            else:
-                time_str = "%d mins ago" % minutes
-
-        # Check if the time is within the last day
-        elif elapsed_time < datetime.timedelta(seconds=60 * 60 * 24 - 1):
-
-            # We know that it's at least an hour, so we can safely round down
-            hours = elapsed_time.seconds / (60 * 60)
-            if hours == 1:
-                time_str = "an hour ago"
-            else:
-                time_str = "%d hours ago" % hours
-
-        # Check if it's within the last N days, where N is a user-supplied
-        # argument
-        elif elapsed_time < datetime.timedelta(days=max_days):
-            if elapsed_time.days == 1:
-                time_str = "yesterday"
-            else:
-                time_str = "%d days ago" % elapsed_time.days
-
-        # If it's not within the last N days, then we're just going to print
-        # the date
-        else:
-            incl_year = (past_time.year != now_time.year)
-            time_str = print_date(past_time,
-                                  incl_year=incl_year,
-                                  short_months=short_months)
-
-    return time_str
 
 ##############################################################################
 ### TYPE FUNCTIONS
@@ -1007,7 +893,7 @@ def promotetolist(obj=None, objtype=None, keepnone=False):
 ### MISC. FUNCTIONS
 ##############################################################################
 
-__all__ += ['now', 'tic', 'toc', 'fixedpause', 'percentcomplete', 'checkmem', 'runcommand', 'gitinfo', 'compareversions', 'uniquename', 'importbyname']
+__all__ += ['now', 'tic', 'toc', 'timedsleep', 'percentcomplete', 'checkmem', 'runcommand', 'gitinfo', 'compareversions', 'uniquename', 'importbyname']
 
 def now(utc=False, die=False, tostring=False, fmt=None):
     ''' Get the current time, optionally in UTC time '''
@@ -1046,6 +932,112 @@ def getdate(obj=None, fmt='str', dateformat=None):
             errormsg = '"fmt=%s" not understood; must be "str" or "int"' % fmt
             raise Exception(errormsg)
         return None # Should not be possible to get to this point
+
+
+
+def elapsedtimestr(past_time, max_days=5, short_months=True):
+    """Accepts a datetime object or a string in ISO 8601 format and returns a
+    human-readable string explaining when this time was.
+    The rules are as follows:
+    * If a time is within the last hour, return 'XX minutes'
+    * If a time is within the last 24 hours, return 'XX hours'
+    * If within the last 5 days, return 'XX days'
+    * If in the same year, print the date without the year
+    * If in a different year, print the date with the whole year
+    These can be configured as options.
+    """
+
+    # Elapsed time function by Alex Chan
+    # https://gist.github.com/alexwlchan/73933442112f5ae431cc
+    def print_date(date, incl_year=True, short_months=True):
+        """Prints a datetime object as a full date, stripping off any leading
+        zeroes from the day (strftime() gives the day of the month as a zero-padded
+        decimal number).
+        """
+        # %b/%B are the tokens for abbreviated/full names of months to strftime()
+        if short_months:
+            month_token = '%b'
+        else:
+            month_token = '%B'
+
+        # Get a string from strftime()
+        if incl_year:
+            date_str = date.strftime('%d ' + month_token + ' %Y')
+        else:
+            date_str = date.strftime('%d ' + month_token)
+
+        # There will only ever be at most one leading zero, so check for this and
+        # remove if necessary
+        if date_str[0] == '0':
+            date_str = date_str[1:]
+
+        return date_str
+    now_time = datetime.datetime.now()
+
+    # If the user passes in a string, try to turn it into a datetime object before continuing
+    if isinstance(past_time, str):
+        try:
+            past_time = datetime.datetime.strptime(past_time, "%Y-%m-%dT%H:%M:%S.%fZ")
+        except ValueError:
+            raise ValueError("User supplied string %s is not in ISO 8601 "
+                             "format." % past_time)
+    elif isinstance(past_time, datetime.datetime):
+        pass
+    else:
+        raise ValueError("User-supplied value %s is neither a datetime object "
+                         "nor an ISO 8601 string." % past_time)
+
+    # It doesn't make sense to measure time elapsed between now and a future date, so we'll just print the date
+    if past_time > now_time:
+        incl_year = (past_time.year != now_time.year)
+        time_str = print_date(past_time,
+                              incl_year=incl_year,
+                              short_months=short_months)
+
+    # Otherwise, start by getting the elapsed time as a datetime object
+    else:
+        elapsed_time = now_time - past_time
+
+        # Check if the time is within the last minute
+        if elapsed_time < datetime.timedelta(seconds=60):
+            if elapsed_time.seconds <= 10:
+                time_str = "just now"
+            else:
+                time_str = "%d secs ago" % elapsed_time.seconds
+
+        # Check if the time is within the last hour
+        elif elapsed_time < datetime.timedelta(seconds=60 * 60):
+
+            # We know that seconds > 60, so we can safely round down
+            minutes = elapsed_time.seconds / 60
+            if minutes == 1:
+                time_str = "a minute ago"
+            else:
+                time_str = "%d mins ago" % minutes
+
+        # Check if the time is within the last day
+        elif elapsed_time < datetime.timedelta(seconds=60 * 60 * 24 - 1):
+
+            # We know that it's at least an hour, so we can safely round down
+            hours = elapsed_time.seconds / (60 * 60)
+            if hours == 1:
+                time_str = "an hour ago"
+            else:
+                time_str = "%d hours ago" % hours
+
+        # Check if it's within the last N days, where N is a user-supplied argument
+        elif elapsed_time < datetime.timedelta(days=max_days):
+            if elapsed_time.days == 1:
+                time_str = "yesterday"
+            else:
+                time_str = "%d days ago" % elapsed_time.days
+
+        # If it's not within the last N days, then we're just going to print the date
+        else:
+            incl_year = (past_time.year != now_time.year)
+            time_str = print_date(past_time, incl_year=incl_year, short_months=short_months)
+
+    return time_str
 
 
 
@@ -1092,15 +1084,15 @@ def toc(start=None, output=False, label=None, sigfigs=None, filename=None):
         return None
 
 
-def fixedpause(delay=None, verbose=True):
+def timedsleep(delay=None, verbose=True):
     '''
     Delay for a certain amount of time, to ensure accurate timing. Example:
 
     for i in range(10):
-        sc.fixedpause('start') # Initialize
+        sc.timedsleep('start') # Initialize
         for j in range(int(1e6)):
             tmp = pl.rand()
-        sc.fixedpause(1) # Wait for one second including computation time
+        sc.timedsleep(1) # Wait for one second including computation time
     '''
     global _delaytime
     if delay is None or delay=='start':
@@ -1110,7 +1102,7 @@ def fixedpause(delay=None, verbose=True):
         try:    
             import pylab as pl
         except Exception as E: 
-            raise Exception('Cannot use fixedpause() since pylab import failed: %s' % str(E))
+            raise Exception('Cannot use timedsleep() since pylab import failed: %s' % str(E))
         try:    start = _delaytime
         except: start = time.time()
         elapsed = time.time() - start

--- a/sciris/sc_utils.py
+++ b/sciris/sc_utils.py
@@ -935,7 +935,7 @@ def getdate(obj=None, fmt='str', dateformat=None):
 
 
 
-def elapsedtimestr(past_time, max_days=5, short_months=True):
+def elapsedtimestr(pasttime, maxdays=5, shortmonths=True):
     """Accepts a datetime object or a string in ISO 8601 format and returns a
     human-readable string explaining when this time was.
     The rules are as follows:
@@ -949,19 +949,19 @@ def elapsedtimestr(past_time, max_days=5, short_months=True):
 
     # Elapsed time function by Alex Chan
     # https://gist.github.com/alexwlchan/73933442112f5ae431cc
-    def print_date(date, incl_year=True, short_months=True):
+    def print_date(date, includeyear=True, shortmonths=True):
         """Prints a datetime object as a full date, stripping off any leading
         zeroes from the day (strftime() gives the day of the month as a zero-padded
         decimal number).
         """
         # %b/%B are the tokens for abbreviated/full names of months to strftime()
-        if short_months:
+        if shortmonths:
             month_token = '%b'
         else:
             month_token = '%B'
 
         # Get a string from strftime()
-        if incl_year:
+        if includeyear:
             date_str = date.strftime('%d ' + month_token + ' %Y')
         else:
             date_str = date.strftime('%d ' + month_token)
@@ -975,28 +975,26 @@ def elapsedtimestr(past_time, max_days=5, short_months=True):
     now_time = datetime.datetime.now()
 
     # If the user passes in a string, try to turn it into a datetime object before continuing
-    if isinstance(past_time, str):
+    if isinstance(pasttime, str):
         try:
-            past_time = datetime.datetime.strptime(past_time, "%Y-%m-%dT%H:%M:%S.%fZ")
+            pasttime = datetime.datetime.strptime(pasttime, "%Y-%m-%dT%H:%M:%S.%fZ")
         except ValueError:
             raise ValueError("User supplied string %s is not in ISO 8601 "
-                             "format." % past_time)
-    elif isinstance(past_time, datetime.datetime):
+                             "format." % pasttime)
+    elif isinstance(pasttime, datetime.datetime):
         pass
     else:
         raise ValueError("User-supplied value %s is neither a datetime object "
-                         "nor an ISO 8601 string." % past_time)
+                         "nor an ISO 8601 string." % pasttime)
 
     # It doesn't make sense to measure time elapsed between now and a future date, so we'll just print the date
-    if past_time > now_time:
-        incl_year = (past_time.year != now_time.year)
-        time_str = print_date(past_time,
-                              incl_year=incl_year,
-                              short_months=short_months)
+    if pasttime > now_time:
+        includeyear = (pasttime.year != now_time.year)
+        time_str = print_date(pasttime, includeyear=includeyear, shortmonths=shortmonths)
 
     # Otherwise, start by getting the elapsed time as a datetime object
     else:
-        elapsed_time = now_time - past_time
+        elapsed_time = now_time - pasttime
 
         # Check if the time is within the last minute
         if elapsed_time < datetime.timedelta(seconds=60):
@@ -1026,7 +1024,7 @@ def elapsedtimestr(past_time, max_days=5, short_months=True):
                 time_str = "%d hours ago" % hours
 
         # Check if it's within the last N days, where N is a user-supplied argument
-        elif elapsed_time < datetime.timedelta(days=max_days):
+        elif elapsed_time < datetime.timedelta(days=maxdays):
             if elapsed_time.days == 1:
                 time_str = "yesterday"
             else:
@@ -1034,8 +1032,8 @@ def elapsedtimestr(past_time, max_days=5, short_months=True):
 
         # If it's not within the last N days, then we're just going to print the date
         else:
-            incl_year = (past_time.year != now_time.year)
-            time_str = print_date(past_time, incl_year=incl_year, short_months=short_months)
+            includeyear = (pasttime.year != now_time.year)
+            time_str = print_date(pasttime, includeyear=includeyear, shortmonths=shortmonths)
 
     return time_str
 

--- a/sciris/sc_utils.py
+++ b/sciris/sc_utils.py
@@ -48,7 +48,7 @@ else:
 
 
 # Define the modules being loaded
-__all__ = ['uuid', 'dcp', 'cp', 'pp', 'sha', 'wget', 'htmlify']
+__all__ = ['uuid', 'dcp', 'cp', 'pp', 'sha', 'wget', 'htmlify', 'elapsed_time_str']
 
 
 def uuid(uid=None, which=None, die=False, tostring=False):
@@ -728,10 +728,122 @@ def colorize(color=None, string=None, output=False, showhelp=False, enable=True)
         except: print(string) # If that fails, just go with plain version
         return None
     
+# Elapsed time function by Alex Chan
+# https://gist.github.com/alexwlchan/73933442112f5ae431cc
+def print_date(date, incl_year=True, short_months=True):
+    """Prints a datetime object as a full date, stripping off any leading
+    zeroes from the day (strftime() gives the day of the month as a zero-padded
+    decimal number).
+    """
+    # %b/%B are the tokens for abbreviated/full names of months to strftime()
+    if short_months:
+        month_token = '%b'
+    else:
+        month_token = '%B'
 
+    # Get a string from strftime()
+    if incl_year:
+        date_str = date.strftime('%d ' + month_token + ' %Y')
+    else:
+        date_str = date.strftime('%d ' + month_token)
 
-        
-    
+    # There will only ever be at most one leading zero, so check for this and
+    # remove if necessary
+    if date_str[0] == '0':
+        date_str = date_str[1:]
+
+    return date_str
+
+def elapsed_time_str(past_time, max_days=5, short_months=True):
+    """Accepts a datetime object or a string in ISO 8601 format and returns a
+    human-readable string explaining when this time was.
+    The rules are as follows:
+    * If a time is within the last hour, return 'XX minutes'
+    * If a time is within the last 24 hours, return 'XX hours'
+    * If within the last 5 days, return 'XX days'
+    * If in the same year, print the date without the year
+    * If in a different year, print the date with the whole year
+    These can be configured as options.
+    """
+    now_time = datetime.datetime.now()
+
+    #--------------------------------------------------------------------------
+    # If the user passes in a string, try to turn it into a datetime object
+    # before continuing
+    #--------------------------------------------------------------------------
+    if isinstance(past_time, str):
+        try:
+            past_time = datetime.datetime.strptime(past_time, "%Y-%m-%dT%H:%M:%S.%fZ")
+        except ValueError:
+            raise ValueError("User supplied string %s is not in ISO 8601 "
+                             "format." % past_time)
+    elif isinstance(past_time, datetime.datetime):
+        pass
+    else:
+        raise ValueError("User-supplied value %s is neither a datetime object "
+                         "nor an ISO 8601 string." % past_time)
+
+    #--------------------------------------------------------------------------
+    # It doesn't make sense to measure time elapsed between now and a future
+    # date, so we'll just print the date
+    #--------------------------------------------------------------------------
+    if past_time > now_time:
+        incl_year = (past_time.year != now_time.year)
+        time_str = print_date(past_time,
+                              incl_year=incl_year,
+                              short_months=short_months)
+
+    #--------------------------------------------------------------------------
+    # Otherwise, start by getting the elapsed time as a datetime object
+    #--------------------------------------------------------------------------
+    else:
+        elapsed_time = now_time - past_time
+
+        # Check if the time is within the last minute
+        if elapsed_time < datetime.timedelta(seconds=60):
+            if elapsed_time.seconds == 1:
+                time_str = "just now"
+            else:
+                time_str = "%d secs ago" % elapsed_time.seconds
+
+        # Check if the time is within the last hour
+        elif elapsed_time < datetime.timedelta(seconds=60 * 60):
+
+            # We know that seconds > 60, so we can safely round down
+            minutes = elapsed_time.seconds / 60
+            if minutes == 1:
+                time_str = "a minute ago"
+            else:
+                time_str = "%d mins ago" % minutes
+
+        # Check if the time is within the last day
+        elif elapsed_time < datetime.timedelta(seconds=60 * 60 * 24 - 1):
+
+            # We know that it's at least an hour, so we can safely round down
+            hours = elapsed_time.seconds / (60 * 60)
+            if hours == 1:
+                time_str = "an hour ago"
+            else:
+                time_str = "%d hours ago" % hours
+
+        # Check if it's within the last N days, where N is a user-supplied
+        # argument
+        elif elapsed_time < datetime.timedelta(days=max_days):
+            if elapsed_time.days == 1:
+                time_str = "yesterday"
+            else:
+                time_str = "%d days ago" % elapsed_time.days
+
+        # If it's not within the last N days, then we're just going to print
+        # the date
+        else:
+            incl_year = (past_time.year != now_time.year)
+            time_str = print_date(past_time,
+                                  incl_year=incl_year,
+                                  short_months=short_months)
+
+    return time_str
+
 ##############################################################################
 ### TYPE FUNCTIONS
 ##############################################################################

--- a/sciris/sc_version.py
+++ b/sciris/sc_version.py
@@ -1,5 +1,5 @@
 __all__ = ['__version__', '__versiondate__', '__license__']
 
-__version__      = '0.13.7'
-__versiondate__  = '2019-05-01'
+__version__      = '0.13.8'
+__versiondate__  = '2019-06-03'
 __license__      = 'Sciris %s (%s) -- (c) Sciris.org' % (__version__, __versiondate__)


### PR DESCRIPTION
This adds a utility `sc.elapsed_time_str` based on https://gist.github.com/alexwlchan/73933442112f5ae431cc that gives a nice human-readable representation of time elapsed. It takes in a datetime, and then internally subtracts it from the current time and returns a human readable string, like

- 'just now'
- '5 minutes ago'
- 'yesterday'

This is a nicer way of displaying recent dates e.g. last modified times, when they have happened recently e.g.

![image](https://user-images.githubusercontent.com/755796/58618288-caf20300-82f4-11e9-93fa-43d16ba0b989.png)