### PR TITLE
saveobj with no filename returns a BytesIO

### DIFF
--- a/sciris/sc_fileio.py
+++ b/sciris/sc_fileio.py
@@ -94,12 +94,12 @@ def saveobj(filename=None, obj=None, compresslevel=5, verbose=0, folder=None, me
 
 
     if filename is None:
-        bytes = io.BytesIO()
+        bytesobj = io.BytesIO()
     else:
         filename = makefilepath(filename=filename, folder=folder, default='default.obj', sanitize=True)
-        bytes = None
+        bytesobj = None
 
-    with GzipFile(filename=filename, fileobj=bytes, mode='wb', compresslevel=compresslevel) as fileobj:
+    with GzipFile(filename=filename, fileobj=bytesobj, mode='wb', compresslevel=compresslevel) as fileobj:
         if method == 'dill': # If dill is requested, use that
             if verbose>=2: print('Saving as dill...')
             savedill(fileobj, obj)
@@ -116,8 +116,8 @@ def saveobj(filename=None, obj=None, compresslevel=5, verbose=0, folder=None, me
     if filename:
         return filename
     else:
-        bytes.seek(0)
-        return bytes
+        bytesobj.seek(0)
+        return bytesobj
 
 
 def dumpstr(obj=None):

--- a/sciris/sc_fileio.py
+++ b/sciris/sc_fileio.py
@@ -91,8 +91,15 @@ def saveobj(filename=None, obj=None, compresslevel=5, verbose=0, folder=None, me
         myobj = ['this', 'is', 'a', 'weird', {'object':44}]
         saveobj('myfile.obj', myobj)
     '''
-    fullpath = makefilepath(filename=filename, folder=folder, default='default.obj', sanitize=True)
-    with GzipFile(fullpath, 'wb', compresslevel=compresslevel) as fileobj:
+
+
+    if filename is None:
+        bytes = io.BytesIO()
+    else:
+        filename = makefilepath(filename=filename, folder=folder, default='default.obj', sanitize=True)
+        bytes = None
+
+    with GzipFile(filename=filename, fileobj=bytes, mode='wb', compresslevel=compresslevel) as fileobj:
         if method == 'dill': # If dill is requested, use that
             if verbose>=2: print('Saving as dill...')
             savedill(fileobj, obj)
@@ -104,8 +111,13 @@ def saveobj(filename=None, obj=None, compresslevel=5, verbose=0, folder=None, me
                 if verbose>=2: print('Exception when saving as pickle (%s), saving as dill...' % repr(E))
                 savedill(fileobj, obj) # ...but use Dill if that fails
         
-    if verbose: print('Object saved to "%s"' % fullpath)
-    return fullpath
+    if verbose and filename: print('Object saved to "%s"' % filename)
+
+    if filename:
+        return filename
+    else:
+        bytes.seek(0)
+        return bytes
 
 
 def dumpstr(obj=None):

--- a/sciris/sc_version.py
+++ b/sciris/sc_version.py
@@ -1,5 +1,5 @@
 __all__ = ['__version__', '__versiondate__', '__license__']
 
-__version__      = '0.13.10'
-__versiondate__  = '2019-06-25'
+__version__      = '0.13.11'
+__versiondate__  = '2019-07-01'
 __license__      = 'Sciris %s (%s) -- (c) Sciris.org' % (__version__, __versiondate__)


### PR DESCRIPTION
This PR makes it so that if no filename is specified, `saveobj` will return a `BytesIO` instance containing the gzipped data. The initial use case is for web apps to serve pickles (e.g. `.prj` files) from `BytesIO` streams rather than writing them to disk. 

@cliffckerr I thought it was a fairly clean implementation to have `filename=None` mean that you don't want to write a file to disk (rather than that resulting in `default.obj` being written) but I don't mind if you prefer something different, as long as the RPC can call `saveobj` and end up somehow with a `BytesIO`