### PR TITLE
Profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,26 @@ Some highlights of `scirisweb`:
 
 ## Is Sciris ready yet?
 
-**Sort of.** Sciris is available for use, but is still undergoing rapid deveopment. We expect a first stable version of Sciris to be ready in early 2019. If you would like us to let you know when it's ready, please email info@sciris.org.
+**Sort of.** Sciris is available for use, but is still undergoing rapid deveopment. We expect a first stable version of Sciris to be ready in early 2020. If you would like us to let you know when it's ready, please email info@sciris.org.
 
 
 ## Installation and run instructions
 
-### Quick start guide
+### 20-second quick start guide
+
+1. Install Sciris: `pip install scirisweb`
+
+2. Download ScirisWeb (e.g. `git clone http://github.com/sciris/scirisweb`)
+
+3. Change to the Hello World folder: `cd scirisweb/examples/helloworld`
+
+4. Run the app: `python app.py`
+
+5. Go to `localhost:8080` in your browser
+
+6. Have fun!
+
+### Medium-quick start guide
 
 Note: if you're a developer, you'll likely already have some/all of these packages installed.
 

--- a/sciris/sc_version.py
+++ b/sciris/sc_version.py
@@ -1,5 +1,5 @@
 __all__ = ['__version__', '__versiondate__', '__license__']
 
-__version__      = '0.15.2'
-__versiondate__  = '2019-12-03'
+__version__      = '0.15.3'
+__versiondate__  = '2019-12-15'
 __license__      = 'Sciris %s (%s) -- (c) Sciris.org' % (__version__, __versiondate__)

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ requirements = [
         'xlsxwriter',         # Spreadsheet output
         'requests',           # HTTP methods
         'python-Levenshtein', # For fuzzy string matching
+        'line_profiler',      # For function profiling
         ]
 
 # Optionally define extras

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,8 @@
 import sciris as sc
 
 torun = [
-# 'colorize',
-# 'printing',
+'colorize',
+'printing',
 'profile',
 ]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,9 @@
 import sciris as sc
 
 torun = [
-'colorize',
-'printing',
+# 'colorize',
+# 'printing',
+'profile',
 ]
 
 # Test colorize
@@ -24,3 +25,35 @@ if 'printing' in torun:
     print('sc.pp():')
     sc.pp(example.data)
     string = sc.pp(example.data, doprint=False)
+    
+    
+# Test profiling functions
+if 'profile' in torun:
+    
+    def slow_fn():
+        n = 10000
+        int_list = []
+        int_dict = {}
+        for i in range(n):
+            int_list.append(i)
+            int_dict[i] = i
+        return
+            
+    class Foo:
+        def __init__(self):
+            self.a = 0
+            return
+        
+        def outer(self):
+            for i in range(100):
+                self.inner()
+            return
+        
+        def inner(self):
+            for i in range(1000):
+                self.a += 1
+            return
+    
+    foo = Foo()
+    sc.profile(run=foo.outer, follow=[foo.outer, foo.inner])
+    sc.profile(slow_fn)


### PR DESCRIPTION
@RomeshA If you have time, could you take a quick look at this? In particular I'm curious if there's a way to get it to not profile the `runwrapper()` part, and/or to simplify this part:

```
    @do_profile(follow=follow) # Add decorator to runmodel function
    def runwrapper():
        run()
    runwrapper()
```

(NB, I accidentally pushed to `develop` instead of the feature branch, which is why this PR is set up oddly!)