### PR TITLE
Change logic

### DIFF
--- a/sciris/sc_fileio.py
+++ b/sciris/sc_fileio.py
@@ -870,8 +870,6 @@ class RobustUnpickler(pickle.Unpickler):
 def unpickler(string=None, filename=None, filestring=None, die=None, verbose=False):
     
     if die is None: die = False
-    obj = RobustUnpickler(io.BytesIO(string)).load()  # And if that trails, throw everything at it
-    return obj
     try: # Try pickle first
         obj = pkl.loads(string) # Actually load it -- main usage case
     except Exception as E1:


### PR DESCRIPTION
The original code had an execution path leading to `obj` being undefined (if the `exec` succeeded but didn't create the variable for whatever reason). However, it seems that at least some of the cases caught by `exec` can instead be handled by using `importlib` rather than just calling `__import__` - this then simplifies the logic where any failure at that point results in `makefailed` being used.

It also wasn't easy to see how to pass `verbose=True` into `find_class` so this PR also changes it to default to `True` so that errors can be identified. This would make bulk imports more noisy (but they're generally scripted anyway) but being verbose is very useful for diagnosing objects with issues