### PR TITLE
Profile changes

### DIFF
--- a/sciris/sc_utils.py
+++ b/sciris/sc_utils.py
@@ -1556,6 +1556,12 @@ def profile(run, follow=None, *args, **kwargs):
     foo = Foo()
     sc.profile(run=foo.outer, follow=[foo.outer, foo.inner])
     sc.profile(slow_fn)
+
+    # Profile the constructor for Foo
+    f = lambda: Foo()
+    sc.profile(run=f, follow=[foo.__init__])
+
+
     '''
 
 


### PR DESCRIPTION
This PR aims to extend `profile()` by allowing arguments to be passed to the `run` function, which would remove the need to wrap simple function calls. It also removes several layers of wrappers which should make the output of `profile()` cleaner in simple cases