### PR TITLE
Default filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 By import convention, components of the Sciris library are listed beginning with `sc.`, e.g. `sc.odict()`.
 
+## Version 0.17.1 (2020-07-07)
+1. `sc.Blobject` has been modified to allow more flexibility with saving (e.g., `Path` objects).
+
 ## Version 0.17.0 (2020-04-27)
 1. `sc.mprofile()` has been added, which does memory profiling just like `sc.profile()`.
 1. `sc.progressbar()` has been added, which prints a progress bar.

--- a/sciris/sc_fileio.py
+++ b/sciris/sc_fileio.py
@@ -580,23 +580,13 @@ class Blobject(object):
         self.modified = ut.now()
         return None
 
-    def save(self, filename=None):
+    def save(self, filename):
         ''' This function writes the spreadsheet to a file on disk. '''
-        if filename is None:
-            if self.filename is not None:
-                filename = self.filename
-            elif self.name is not None:
-                if self.name.endswith('.xlsx'):
-                    filename = self.name
-                else:
-                    filename = self.name + '.xlsx'
-            else:
-                filename = 'spreadsheet.xlsx' # Come up with a terrible default name
         filepath = makefilepath(filename=filename)
         with open(filepath, mode='wb') as f:
             f.write(self.blob)
         self.filename = filename
-        print('Spreadsheet saved to %s.' % filepath)
+        print('Object saved to %s.' % filepath)
         return filepath
 
     def tofile(self, output=True):
@@ -774,9 +764,9 @@ class Spreadsheet(Blobject):
 
         return None
 
-
-    pass
-
+    def save(self, filename='spreadsheet.xlsx'):
+        filepath = makefilepath(filename=filename, ext='xlsx')
+        super().save(filepath)
 
 def loadspreadsheet(filename=None, folder=None, fileobj=None, sheetname=None, sheetnum=None, asdataframe=None, header=True, cells=None):
     '''

--- a/sciris/sc_fileio.py
+++ b/sciris/sc_fileio.py
@@ -580,7 +580,7 @@ class Blobject(object):
         self.modified = ut.now()
         return None
 
-    def save(self, filename):
+    def save(self, filename=None):
         ''' This function writes the spreadsheet to a file on disk. '''
         filepath = makefilepath(filename=filename)
         with open(filepath, mode='wb') as f:

--- a/sciris/sc_utils.py
+++ b/sciris/sc_utils.py
@@ -1355,7 +1355,7 @@ def elapsedtimestr(pasttime, maxdays=5, shortmonths=True):
         elif elapsed_time < datetime.timedelta(seconds=60 * 60):
 
             # We know that seconds > 60, so we can safely round down
-            minutes = elapsed_time.seconds / 60
+            minutes = int(elapsed_time.seconds / 60)
             if minutes == 1:
                 time_str = "a minute ago"
             else:
@@ -1365,9 +1365,9 @@ def elapsedtimestr(pasttime, maxdays=5, shortmonths=True):
         elif elapsed_time < datetime.timedelta(seconds=60 * 60 * 24 - 1):
 
             # We know that it's at least an hour, so we can safely round down
-            hours = elapsed_time.seconds / (60 * 60)
+            hours = int(elapsed_time.seconds / (60 * 60))
             if hours == 1:
-                time_str = "an hour ago"
+                time_str = "1 hour ago"
             else:
                 time_str = "%d hours ago" % hours
 

--- a/sciris/sc_version.py
+++ b/sciris/sc_version.py
@@ -1,5 +1,5 @@
 __all__ = ['__version__', '__versiondate__', '__license__']
 
-__version__      = '0.17.0'
-__versiondate__  = '2020-04-27'
+__version__      = '0.17.1'
+__versiondate__  = '2020-07-07'
 __license__      = 'Sciris %s (%s) -- (c) Sciris.org' % (__version__, __versiondate__)


### PR DESCRIPTION
The main change is that `Blobject.save` had defaults specific to spreadsheets, which are better specified in `Spreadsheet.save` since `Blobject` instances could be storing any time of binary content. This refactored implementation then leverages the existing functionality in `makefilepath` to ensure that `Spreadsheet` files end in `.xlsx` as well as allowing users to pass in a `Path` instance as the filename

