### PR TITLE
Fix shared object bug in parallization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 By import convention, components of the Sciris library are listed beginning with `sc.`, e.g. `sc.odict()`.
 
+## Version 0.17.3 (2020-07-21)
+1. `sc.parallelize()` now explicitly deep-copies objects, since on some platforms this copying does not take place as part of the parallelization process.
+
 ## Version 0.17.2 (2020-07-13)
 1. `sc.search()` is a new function to find nested attributes/keys within objects or dictionaries.
 

--- a/sciris/sc_parallel.py
+++ b/sciris/sc_parallel.py
@@ -287,6 +287,7 @@ def parallel_task(taskargs, outputqueue=None):
     ''' Task called by parallelize() -- not to be called directly '''
     
     # Handle inputs
+    taskargs = ut.dcp(taskargs)
     func   = taskargs.func
     index  = taskargs.index
     args   = taskargs.args

--- a/sciris/sc_version.py
+++ b/sciris/sc_version.py
@@ -1,5 +1,5 @@
 __all__ = ['__version__', '__versiondate__', '__license__']
 
-__version__      = '0.17.2'
-__versiondate__  = '2020-07-13'
+__version__      = '0.17.3'
+__versiondate__  = '2020-07-21'
 __license__      = 'Sciris %s (%s) -- (c) Sciris.org' % (__version__, __versiondate__)


### PR DESCRIPTION
Stumbled onto this subtle issue with parallelization. It looks very much like if a mutable object is passed in as an argument, at least inside `kwargs`, under *some* circumstances it is possible that a worker process will reuse the same object in memory. It doesn't happen in an obviously predictable way with regard to the inputs e.g. if I have 4 CPUs, doing 4, 8, or even 12 tasks is fine, but the issue reproducibly happens when using >20 tasks, at least on my 4 core machine. This example is modelled after `covasim.MultiSim`:

```
import sciris as sc
import numpy as np

class Foo():
    def __init__(self):
        self.x = 0

    def add(self,x):
        self.x += x

def add(obj,val):
    obj.add(val)
    return obj

if __name__ == '__main__':

    n_runs = 4
    test_obj = Foo()
    iterkwargs = {'val': np.arange(n_runs)}
    kwargs = dict(obj=test_obj)
    objs = sc.parallelize(add, iterkwargs=iterkwargs, kwargs=kwargs)
    print([y.x for y in objs])
    print([id(y) for y in objs])
```

Running this gives

- `n_runs=4` : `[0, 1, 2, 3]` (correct)
- `n_runs=8`: `[0, 1, 2, 3, 4, 5, 6, 7]` (correct)
- `n_runs=20`: `[1, 1, 5, 5, 9, 9, 13, 13, 17, 17, 21, 21, 25, 25, 29, 29, 33, 33, 37, 37]` (incorrect)

The output of `id()` confirms than in the last example, there are only 10 unique objects in memory. The problem is fixed by the change in this PR by just adding a `dcp()` inside the task function to make sure the inputs are unique objects in each function call. 

New output:

- `n_runs=20`: `[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]` (correct)

This is also an issue because of the bug in https://github.com/amath-idm/covasim/issues/610 - when using `covasim.MultiSim` if circumstances mean that this bug is encountered then the reproducible runs issue means that not only will there be many fewer unique runs than expected, all of those runs will likely be wrong due to the `Sim` not having been reset properly (I came across this bug in `sc.parallelize` because of getting unexpected results with `MultiSim`). Haven't checked, but it may also affect `cv.Scenarios` as it's more or less the same pathway to `sc.parallelize` via `multi_run` 
