### PR TITLE
Fix prepr() for __slots__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 By import convention, components of the Sciris library are listed beginning with `sc.`, e.g. `sc.odict()`.
 
+
+## Version 0.17.4 (2020-08-11)
+1. `sc.profile()` and `sc.mprofile()` now return the line profiler instance for later use (e.g., to extract additional statistics).
+1. `sc.prepr()` (also used in `sc.prettyobj()`) can now support objects with slots instead of dicts.
+
 ## Version 0.17.3 (2020-07-21)
 1. `sc.parallelize()` now explicitly deep-copies objects, since on some platforms this copying does not take place as part of the parallelization process.
 

--- a/sciris/sc_utils.py
+++ b/sciris/sc_utils.py
@@ -2148,7 +2148,7 @@ def search(obj, attribute, _trace=''):
 ### CLASSES
 ##############################################################################
 
-__all__ += ['KeyNotFoundError', 'LinkException', 'prettyobj', 'Link', 'Timer', 'cachefile']
+__all__ += ['KeyNotFoundError', 'LinkException', 'prettyobj', 'Link', 'Timer']
 
 
 class KeyNotFoundError(KeyError):
@@ -2292,5 +2292,3 @@ class Timer(object):
         '''
 
         toc(self.start,**self.kwargs)
-
-

--- a/sciris/sc_utils.py
+++ b/sciris/sc_utils.py
@@ -2296,31 +2296,3 @@ class Timer(object):
         toc(self.start,**self.kwargs)
 
 
-def cachefile(fcn):
-
-    @wraps(fcn)
-    def wrapper(*args, **kwargs):
-
-        try:
-            hash = hashlib.sha1(pickle.dumps((args,kwargs))).hexdigest()[0:8]
-        except pickle.PicklingError:
-            print('Argument is not picklable, will not cache function run')
-            return fcn(*args, **kwargs)
-
-        fname = f'_cachefile_{fcn.__name__}_{hash}'
-
-        try:
-            print(f'Trying cache file {fname}')
-            return loadobj(fname, die=True)
-        except (FileNotFoundError, pickle.UnpicklingError):
-            print('Cache file not successful, re-running function')
-            val = fcn(*args, **kwargs)
-            try:
-                saveobj(fname, val)
-                print('Saved cache file for next run')
-            except Exception as E:
-                print(f'Cache error: {str(E)}')
-
-            return val
-
-    return wrapper

--- a/sciris/sc_utils.py
+++ b/sciris/sc_utils.py
@@ -10,7 +10,6 @@ import copy
 import time
 import json
 import pprint
-import pickle
 import hashlib
 import datetime
 import dateutil
@@ -23,10 +22,9 @@ import uuid as py_uuid
 import tempfile
 import traceback as py_traceback
 from textwrap import fill
-from functools import reduce, wraps
+from functools import reduce
 from collections import OrderedDict as OD
 from distutils.version import LooseVersion
-from .sc_fileio import loadobj, saveobj
 
 # Handle types and legacy Python 2 compatibility
 import urllib.request as urlrequester

--- a/sciris/sc_utils.py
+++ b/sciris/sc_utils.py
@@ -1834,17 +1834,18 @@ def suggest(user_input, valid_inputs, n=1, threshold=4, fulloutput=False, die=Fa
                 return suggestions[:n]
 
 
-def profile(run, follow=None, *args, **kwargs):
+def profile(run, follow=None, print_stats=True, *args, **kwargs):
     '''
     Profile the line-by-line time required by a function.
 
     Args:
         run (function): The function to be run
         follow (function): The function or list of functions to be followed in the profiler; if None, defaults to the run function
+        print_stats (bool): whether to print the statistics of the profile to stdout
         args, kwargs: Passed to the function to be run
 
     Returns:
-        None (the profile output is printed to stdout)
+        LineProfiler (by default, the profile output is also printed to stdout)
 
     Example
     -------
@@ -1897,16 +1898,17 @@ def profile(run, follow=None, *args, **kwargs):
     lp.enable_by_count()
     wrapper = lp(run)
 
-    print('Profiling...')
+    if print_stats:
+        print('Profiling...')
     wrapper(*args, **kwargs)
-    lp.print_stats()
     run = orig_func
-    print('Done.')
+    if print_stats:
+        lp.print_stats()
+        print('Done.')
+    return lp
 
-    return
 
-
-def mprofile(run, follow=None, *args, **kwargs):
+def mprofile(run, follow=None, show_results=True, *args, **kwargs):
     '''
     Profile the line-by-line memory required by a function. See profile() for a
     usage example.
@@ -1914,10 +1916,11 @@ def mprofile(run, follow=None, *args, **kwargs):
     Args:
         run (function): The function to be run
         follow (function): The function or list of functions to be followed in the profiler; if None, defaults to the run function
+        show_results (bool): whether to print the statistics of the profile to stdout
         args, kwargs: Passed to the function to be run
 
     Returns:
-        None (the profile output is printed to stdout)
+        LineProfiler (by default, the profile output is also printed to stdout)
     '''
 
     try:
@@ -1938,12 +1941,13 @@ def mprofile(run, follow=None, *args, **kwargs):
     except TypeError as e:
         raise TypeError('Function wrapping failed; are you profiling an already-profiled function?') from e
 
-    print('Profiling...')
+    if show_results:
+        print('Profiling...')
     wrapper(*args, **kwargs)
-    mp.show_results(lp)
-    print('Done.')
-
-    return
+    if show_results:
+        mp.show_results(lp)
+        print('Done.')
+    return lp
 
 
 

--- a/sciris/sc_version.py
+++ b/sciris/sc_version.py
@@ -1,5 +1,5 @@
 __all__ = ['__version__', '__versiondate__', '__license__']
 
-__version__      = '0.17.3'
-__versiondate__  = '2020-07-21'
+__version__      = '0.17.4'
+__versiondate__  = '2020-08-11'
 __license__      = 'Sciris %s (%s) -- (c) Sciris.org' % (__version__, __versiondate__)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,6 +93,17 @@ def test_prepr():
     print(myobj)
     return myobj
 
+def test_prepr_slots():
+    sc.heading('Test pretty representation of an object using slots')
+
+    class Foo():
+        __slots__ = ['bar']
+        def __init__(self):
+            self.bar = 1
+
+    x = Foo()
+    sc.prepr(x)
+    return None
 
 def test_uuid():
     sc.heading('Test UID generation')
@@ -304,6 +315,7 @@ if __name__ == '__main__':
     string    = test_printing()
     foo       = test_profile()
     myobj     = test_prepr()
+    test_prepr_slots()
     uid       = test_uuid()
     plist     = test_promotetolist()
     dists     = test_suggest()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,12 +75,12 @@ def test_profile():
     foo = Foo()
     try:
         sc.mprofile(big_fn) # NB, cannot re-profile the same function at the same time
-    except TypeError: # This happens when re-running this script
-        pass
+    except TypeError as E: # This happens when re-running this script
+        print(f'Unable to re-profile memory function; this is usually not cause for concern ({E})')
     sc.profile(run=foo.outer, follow=[foo.outer, foo.inner])
-    sc.profile(slow_fn)
+    lp = sc.profile(slow_fn)
 
-    return foo
+    return lp
 
 
 def test_prepr():
@@ -93,6 +93,7 @@ def test_prepr():
     print(myobj)
     return myobj
 
+
 def test_prepr_slots():
     sc.heading('Test pretty representation of an object using slots')
 
@@ -102,8 +103,9 @@ def test_prepr_slots():
             self.bar = 1
 
     x = Foo()
-    sc.prepr(x)
-    return None
+    print(sc.prepr(x))
+    return x
+
 
 def test_uuid():
     sc.heading('Test UID generation')
@@ -313,9 +315,9 @@ if __name__ == '__main__':
 
     bluearray = test_colorize()
     string    = test_printing()
-    foo       = test_profile()
+    lp        = test_profile()
     myobj     = test_prepr()
-    test_prepr_slots()
+    myobj2    = test_prepr_slots()
     uid       = test_uuid()
     plist     = test_promotetolist()
     dists     = test_suggest()


### PR DESCRIPTION
Class instances might not have a `__dict__` defined if the class uses `__slots__` instead, which causes an infinite recursion in `prepr()` if such an object is encountered. This PR modifies `prepr()` to use `__slots__` for such classes