### PR TITLE
Drop cache

### DIFF
--- a/sciris/sc_fileio.py
+++ b/sciris/sc_fileio.py
@@ -877,6 +877,10 @@ class Spreadsheet(Blobject):
         self.wb = None
         return
 
+    def __getstate__(self):
+        d = self.__dict__.copy() # Shallow copy
+        d['wb'] = None
+        return d
 
     def _reload_wb(self, reload=None):
         ''' Helper function to check if workbook is already loaded '''


### PR DESCRIPTION
This PR adds a `__getstate__` implementation to `sc.Spreadsheet` to drop the workbook cache when serializing (e.g., when using dcp or saveobj). If the cached workbook is not discarded, these operations become much slower because the content of the file is being duplicated in a heavy container. This is particularly problematic when operating on larger spreadsheets. For example

```
import sciris as sc

with sc.Timer('create spreadsheet'):
    ss = sc.Spreadsheet('iicf_mnch_20200121_v1.xlsx')

with sc.Timer('save blob1'):
    sc.saveobj('test1',ss)

with sc.Timer('open wb'):
    ss.openpyxl()

with sc.Timer('dcp'):
    sc.dcp(ss)

with sc.Timer('save blob2'):
    sc.saveobj('test2',ss)
```

With a 6mb spreadsheet, without dropping the cache, the timings are

```
create spreadsheet: 0.00300 s
save blob1: 0.205 s
open wb: 18.0 s
dcp: 44.5 s
save blob2: 11.9 s
```

and while the first blob is 6mb in size, the second blob is 18mb in size - over double.

With this PR:

```
create spreadsheet: 0.00200 s
save blob1: 0.206 s
open wb: 18.7 s
dcp: 0.00200 s
save blob2: 0.209 s
```

and both files on disk are the same size.

The other important consideration is that many use cases embed spreadsheet instances in other classes e.g., `Project` objects. If it's necessary to manually `close` the spreadsheet every time, a developer only has to forget to include it once to have the `Project` massively increase in size and for performance to be severely impacted, which is particularly problematic for web applications where the objects are frequently and almost automatically written to a database, so performance could suddenly and semi-permanently be affected

