### PR TITLE
Revert Matplotlib change

### DIFF
--- a/sciris/sc_colors.py
+++ b/sciris/sc_colors.py
@@ -197,7 +197,7 @@ def vectocolor(vector, cmap=None, asarray=True, reverse=False, minval=None, maxv
         cmap = pl.get_cmap() # Get current colormap
     elif type(cmap) == str:
         try:
-            cmap = mplcm.get_cmap(cmap)
+            cmap = pl.get_cmap(cmap)
         except: # pragma: no cover
             choices = scu.newlinejoin(pl.colormaps())
             raise ValueError(f'{cmap} is not a valid color map; choices are:\n{choices}')
@@ -770,8 +770,8 @@ def orangebluecolormap(apply=False):
 
     New in version 1.0.0.
     '''
-    bottom = mplcm.get_cmap('Oranges').resampled(128)
-    top = mplcm.get_cmap('Blues_r').resampled(128)
+    bottom = pl.get_cmap('Oranges').resampled(128)
+    top = pl.get_cmap('Blues_r').resampled(128)
     x = np.linspace(0, 1, 128)
     data = np.vstack((top(x), bottom(x)))
 
@@ -796,4 +796,4 @@ for origname,cmap in colormap_map.items():
     newname = f'sciris-{origname}'
     for name in [origname, newname]:
         if name not in existing: # Avoid re-registering already registered colormaps
-            mplcm.register(name=name, cmap=cmap)
+            pl.register_cmap(name=name, cmap=cmap)

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -166,9 +166,9 @@ def test_tictoc():
     # Check relative timings
     T = sc.timer()
     T.start()
-    nap()
+    nap(1)
     T.tt()
-    nap(2)
+    nap(5)
     T.tt()
     print(T.timings)
     assert T.timings[0] < T.timings[1]

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -91,7 +91,7 @@ def test_resourcemonitor():
 
     def callback(checkdata, checkstr):
         ''' Small function to test that callbacks work '''
-        print('Callback was executed')
+        print('Callback works as intended')
         o.callback.append(checkdata)
         return
 
@@ -103,8 +103,8 @@ def test_resourcemonitor():
     o.resmon_died = resmon
 
     # As a standalone (don't forget to call stop!)
-    resmon = sc.resourcemonitor(mem=0.95, cpu=0.9, time=0.3, interval=0.1, label='Load checker', die=False, callback=callback, verbose=True)
-    sc.timedsleep(0.5)
+    resmon = sc.resourcemonitor(mem=0.95, cpu=0.99, time=0.2, interval=0.1, label='Load checker', die=False, callback=callback, verbose=True)
+    sc.timedsleep(0.3)
     resmon.stop()
     print(resmon.to_df())
 


### PR DESCRIPTION
Revert Matplotlib change, which is a deprecation in 3.6.1, but the alternative is an error in previous versions.