### PR TITLE
Fix filename=None behaviour

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ All major updates to Sciris are documented here.
 
 By import convention, components of the Sciris library are listed beginning with ``sc.``, e.g. ``sc.odict()``.
 
+Version 2.0.5 (2022-11-30)
+--------------------------
+#. Fixed bug where `sc.save(filename=None, )` would incorrectly result in creation of a file on disk in addition to returning a ``io.BytesIO`` stream
+
 
 Version 2.0.4 (2022-10-25)
 --------------------------

--- a/sciris/sc_version.py
+++ b/sciris/sc_version.py
@@ -4,6 +4,6 @@ Version and license information.
 
 __all__ = ['__version__', '__versiondate__', '__license__']
 
-__version__      = '2.0.4'
-__versiondate__  = '2022-10-25'
+__version__      = '2.0.5'
+__versiondate__  = '2022-11-30'
 __license__      = f'Sciris {__version__} ({__versiondate__}) – © 2014-2022 by the Sciris Development Team'


### PR DESCRIPTION
`sc.save()` supports passing in `filename=None` to create the file in-memory as a file stream. However, the existing logic results in the filename being re-populated with the default value, preventing the `io.BytesIO` pathway from being used. This PR refactors the logic for input validation to correct this.

Also, it looked like previously if the filename could not be validated, an error message was defined, but it would not be raised. An exception is now raised once the error message is defined