### PR TITLE
FIX: correct invocation of deps installation in tests README.rst

### DIFF
--- a/tests/README.rst
+++ b/tests/README.rst
@@ -7,7 +7,7 @@ This folder contains the core tests for Sciris.
 Installation
 ------------
 
-To install test dependencies, use ``pip install -r requirements_test.txt``. (Note: ``pytest-parallel`` is used instead of ``pytest-xdist`` since it has much less overhead for running fast tests.)
+To install test dependencies, use ``pip install -r requirements.txt``. (Note: ``pytest-parallel`` is used instead of ``pytest-xdist`` since it has much less overhead for running fast tests.)
 
 Usage
 -----


### PR DESCRIPTION
It is very surprising to me that invoking `pytest` from the top of the repo fails but invoking it from inside of the test directory works. 