### PR TITLE
Fix sc.download HTML error handling

### DIFF
--- a/sciris/sc_parallel.py
+++ b/sciris/sc_parallel.py
@@ -844,8 +844,7 @@ def _task(taskargs):
     except Exception as E: # pragma: no cover
         if taskargs.die: # Usual case, raise an exception and stop
             errormsg = f'Task {index} failed: set die=False to keep going instead; see above for error details'
-            exc = type(E)
-            raise exc(errormsg) from E
+            raise Exception(errormsg) from E
         else: # Alternatively, keep going and just let this trial fail
             warnmsg = f'sc.parallelize(): Task {index} failed, but die=False so continuing.\n{scu.traceback()}'
             warnings.warn(warnmsg, category=RuntimeWarning, stacklevel=2)


### PR DESCRIPTION
There is no need to return an exception of the same type as the original exception. We can return our own exception, and it will be clear which exception it originates from, because we're using `from`, causing the original exception to also be printed.

Fixes #527