### PR TITLE
Fix timedsleep verbose=True timing

### DIFF
--- a/sciris/sc_datetime.py
+++ b/sciris/sc_datetime.py
@@ -1308,13 +1308,13 @@ def timedsleep(delay=None, start=None, verbose=False):
             except: start = pytime.time()
         elapsed = pytime.time() - start
         remaining = max(1e-12, delay - elapsed - _sleep_overhead)
-        pytime.sleep(remaining)
-        try:    del _delaytime # After it's been used, we can't use it again
-        except: pass
         if remaining > 0 and verbose:
             print(f'Pausing for {remaining:n} s')
         elif verbose: # pragma: no cover
             print(f'Warning, delay less than elapsed time ({delay:n} vs. {elapsed:n})')
+        pytime.sleep(remaining)
+        try:    del _delaytime # After it's been used, we can't use it again
+        except: pass
     return
 
 


### PR DESCRIPTION
Previously, timedsleep printed the “Sleeping for...” text after sleeping when called with verbose=True. Now, the message is printed before sleeping, as it should be.

Fixes #526