### PR TITLE
Fix https://github.com/sciris/sciris/issues/557 by merging dictionaries into a new kwargs for each task

### DIFF
--- a/sciris/sc_parallel.py
+++ b/sciris/sc_parallel.py
@@ -809,9 +809,7 @@ def _task(taskargs):
             taskargs.iterval = (taskargs.iterval,)
         if not taskargs.embarrassing:
             args = taskargs.iterval + args # If variable name is not supplied, prepend it to args
-    if taskargs.iterdict is not None:
-        for key,val in taskargs.iterdict.items():
-            kwargs[key] = val # Otherwise, include it in kwargs
+    kwargs = scu.mergedicts(kwargs, taskargs.iterdict) # Merge this iterdict, overwriting kwargs if there are conflicts
 
     # Handle load balancing
     maxcpu = taskargs.maxcpu


### PR DESCRIPTION
Hi @cliffckerr 

I think this should fix https://github.com/sciris/sciris/issues/557 if the intended behaviour is that if `kwargs` and `iterkwargs` share keys, then `iterkwargs` overrides `kwargs`?

Let me know what you think, and feel free to push commits to this branch

Thanks,
Kelvin