### PR TITLE
Fix sc_asd.py final print of `best` and `ratio`

### DIFF
--- a/sciris/sc_asd.py
+++ b/sciris/sc_asd.py
@@ -258,7 +258,7 @@ def asd(function, x, args=None, stepsize=0.1, sinc=2, sdec=2, pinc=2, pdec=2,
 
     # Return
     if verbose > 0:
-        orig, best, ratio = scp.sigfig([fvals[0], fvals[-1], fvals[-1]/fvals[0]])
+        orig, best, ratio = scp.sigfig([fvals[0], fvals[count], fvals[count]/fvals[0]])
         print(f'=== {label} {exitreason} ({count} steps, orig: {orig} | best: {best} | ratio: {ratio}) ===')
     output = sco.objdict()
     output['x'] = np.reshape(x, origshape) # Parameters


### PR DESCRIPTION
Hi @cliffckerr 

Small bug in the verbose printing: the correct final function value is at `fvals[count]` both when we converge or stop early and when it reaches maxiters

I fixed this in `optima` already in https://github.com/optimamodel/optima/commit/5e027ea22808652a648f9bcd374919467ea51bde

Should be easy enough to go into 3.1.3?

I'm not sure why there is a change in the diff at the bottom of the file - I didn't change anything there... Feel free to do the change yourself on your end.

Thanks!