### PR TITLE
Set class name correctly for derived classes e.g., ndict

### DIFF
--- a/sciris/sc_odict.py
+++ b/sciris/sc_odict.py
@@ -1151,7 +1151,7 @@ class objdict(odict):
 
     def __repr__(self, *args, **kwargs):
         """ Use odict repr, but with a custom class name and no quotes """
-        return odict.__repr__(self, quote='', numsep='.', classname='objdict', *args, **kwargs)
+        return odict.__repr__(self, quote='', numsep='.', classname=self.__class__.__name__, *args, **kwargs)
 
 
     def __getattribute__(self, attr):


### PR DESCRIPTION
Tiny change so that subclasses of `objdict` (e.g., `ndict`) print their actual class name rather than always printing `objdict`