### PR TITLE
Implement fix

### DIFF
--- a/sciris/__init__.py
+++ b/sciris/__init__.py
@@ -39,3 +39,8 @@ if not _lazy:
     from .sc_colors     import *
 
 del _os, _lazy, _threads
+
+# Fix loading legacy objects
+import sciris
+sciris.sc_utils.prettyobj = sciris.sc_printing.prettyobj
+


### PR DESCRIPTION
This PR has an example fix for a migration error we're getting in Atomica. The issue seems to be that `prettyobj` was moved from `sc_utils` to `sc_printing` so when unpickling, the class can't be found. I've implemented one possible fix in this PR (this is the approach Atomica uses, except those mappings are in `migration.py` rather than `__init__.py` - there's no direct analogue of that in Sciris). But there's a ton of different ways to do it, so happy for you to do something different!

```
Traceback (most recent call last):
  File "/Users/romesh.abeysuriya/miniconda3/envs/atomica311/lib/python3.11/site-packages/IPython/core/interactiveshell.py", line 3526, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-2-201782cde910>", line 1, in <module>
    runfile('/Users/romesh.abeysuriya/projects/atomica/tests/test_tox_migration.py', wdir='/Users/romesh.abeysuriya/projects/atomica/tests')
  File "/Users/romesh.abeysuriya/Applications/PyCharm Professional Edition.app/Contents/plugins/python/helpers/pydev/_pydev_bundle/pydev_umd.py", line 197, in runfile
    pydev_imports.execfile(filename, global_vars, local_vars)  # execute the script
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/romesh.abeysuriya/Applications/PyCharm Professional Edition.app/Contents/plugins/python/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/Users/romesh.abeysuriya/projects/atomica/tests/test_tox_migration.py", line 38, in <module>
    test_migration()
  File "/Users/romesh.abeysuriya/projects/atomica/tests/test_tox_migration.py", line 20, in test_migration
    P = at.Project.load(testdir / "migration_test_with_scenarios.prj")
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/romesh.abeysuriya/projects/atomica/atomica/project.py", line 699, in load
    P = sc.loadobj(filepath, die=True)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/romesh.abeysuriya/projects/sciris/sciris/sc_fileio.py", line 187, in load
    obj = _unpickler(filestr, **kw, **kwargs) # Unpickle the data
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/romesh.abeysuriya/projects/sciris/sciris/sc_fileio.py", line 2454, in _unpickler
    raise UnpicklingError(errormsg)
sciris.sc_fileio.UnpicklingError: All available unpickling methods failed: pickle: Traceback (most recent call last):
  File "/Users/romesh.abeysuriya/projects/sciris/sciris/sc_fileio.py", line 2446, in _unpickler
    obj = methods[unpickler](string, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: Can't get attribute 'prettyobj' on <module 'sciris.sc_utils' from '/Users/romesh.abeysuriya/projects/sciris/sciris/sc_utils.py'>
pandas: Traceback (most recent call last):
  File "/Users/romesh.abeysuriya/projects/sciris/sciris/sc_fileio.py", line 2446, in _unpickler
    obj = methods[unpickler](string, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/romesh.abeysuriya/projects/sciris/sciris/sc_fileio.py", line 2421, in <lambda>
    pandas = lambda s, **kw: pd.read_pickle(io.BytesIO(s), **kw),
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/romesh.abeysuriya/miniconda3/envs/atomica311/lib/python3.11/site-packages/pandas/io/pickle.py", line 207, in read_pickle
    return pc.load(handles.handle, encoding=None)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/romesh.abeysuriya/miniconda3/envs/atomica311/lib/python3.11/site-packages/pandas/compat/pickle_compat.py", line 231, in load
    return up.load()
           ^^^^^^^^^
  File "/Users/romesh.abeysuriya/miniconda3/envs/atomica311/lib/python3.11/pickle.py", line 1213, in load
    dispatch[key[0]](self)
  File "/Users/romesh.abeysuriya/miniconda3/envs/atomica311/lib/python3.11/pickle.py", line 1538, in load_stack_global
    self.append(self.find_class(module, name))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/romesh.abeysuriya/miniconda3/envs/atomica311/lib/python3.11/site-packages/pandas/compat/pickle_compat.py", line 162, in find_class
    return super().find_class(module, name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/romesh.abeysuriya/miniconda3/envs/atomica311/lib/python3.11/pickle.py", line 1582, in find_class
    return _getattribute(sys.modules[module], name)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/romesh.abeysuriya/miniconda3/envs/atomica311/lib/python3.11/pickle.py", line 331, in _getattribute
    raise AttributeError("Can't get attribute {!r} on {!r}"
AttributeError: Can't get attribute 'prettyobj' on <module 'sciris.sc_utils' from '/Users/romesh.abeysuriya/projects/sciris/sciris/sc_utils.py'>
latin: Traceback (most recent call last):
  File "/Users/romesh.abeysuriya/projects/sciris/sciris/sc_fileio.py", line 2446, in _unpickler
    obj = methods[unpickler](string, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/romesh.abeysuriya/projects/sciris/sciris/sc_fileio.py", line 2420, in <lambda>
    latin  = lambda s, **kw: pkl.loads(s, encoding=kw.pop('encoding', 'latin1'), **kw),
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: Can't get attribute 'prettyobj' on <module 'sciris.sc_utils' from '/Users/romesh.abeysuriya/projects/sciris/sciris/sc_utils.py'>
dill: Traceback (most recent call last):
  File "/Users/romesh.abeysuriya/projects/sciris/sciris/sc_fileio.py", line 2446, in _unpickler
    obj = methods[unpickler](string, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/romesh.abeysuriya/miniconda3/envs/atomica311/lib/python3.11/site-packages/dill/_dill.py", line 301, in loads
    return load(file, ignore, **kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/romesh.abeysuriya/miniconda3/envs/atomica311/lib/python3.11/site-packages/dill/_dill.py", line 287, in load
    return Unpickler(file, ignore=ignore, **kwds).load()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/romesh.abeysuriya/miniconda3/envs/atomica311/lib/python3.11/site-packages/dill/_dill.py", line 442, in load
    obj = StockUnpickler.load(self)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/romesh.abeysuriya/miniconda3/envs/atomica311/lib/python3.11/site-packages/dill/_dill.py", line 432, in find_class
    return StockUnpickler.find_class(self, module, name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: Can't get attribute 'prettyobj' on <module 'sciris.sc_utils' from '/Users/romesh.abeysuriya/projects/sciris/sciris/sc_utils.py'>
```
