### PR TITLE
3 changes to sc.nested

### DIFF
--- a/sciris/sc_nested.py
+++ b/sciris/sc_nested.py
@@ -151,6 +151,15 @@ def get_from_obj(ndict, key, safe=False, **kwargs):
         out = None
     return out
 
+def set_to_obj(parent, key, value):
+    """ Set the value for the item """
+    itertype = check_iter_type(parent)
+    if itertype in ['dict', 'list']:
+        parent[key] = value
+    elif itertype == 'object':
+        parent.__dict__[key] = value
+    else: raise Exception(f'Cannot set value for type "{type(parent)}", itertype "{itertype}"')
+    return
 
 def getnested(nested, keylist, safe=False):
     """
@@ -172,7 +181,7 @@ def getnested(nested, keylist, safe=False):
     return nested
 
 
-def setnested(nested, keylist, value, force=True):
+def setnested(nested, keylist, value, force=None):
     """
     Set the value for the given list of keys
     
@@ -188,14 +197,11 @@ def setnested(nested, keylist, value, force=True):
 
     See :func:`sc.makenested() <makenested>` for full documentation.
     """
+    if force is None: force = isinstance(nested, dict)
     if force:
         makenested(nested, keylist, overwrite=False)
     currentlevel = getnested(nested, keylist[:-1])
-    if not isinstance(currentlevel, dict): # pragma: no cover
-        errormsg = f'Cannot set {keylist} since parent is a {type(currentlevel)}, not a dict'
-        raise TypeError(errormsg)
-    else:
-        currentlevel[keylist[-1]] = value
+    set_to_obj(currentlevel, keylist[-1], value)
     return nested # Return object, but note that it's modified in place
 
 

--- a/sciris/sc_nested.py
+++ b/sciris/sc_nested.py
@@ -322,6 +322,7 @@ class IterObj:
         
         # Handle objects to skip
         if isinstance(skip, dict):
+            skip = scu.dcp(skip)
             skip_ids        = scu.tolist(skip.pop('ids', None))
             skip_subclasses = scu.tolist(skip.pop('subclasses', None))
             skip_instances  = scu.tolist(skip.pop('instances', None))


### PR DESCRIPTION
[Fix IterObj clearing skip argument if it is a dict, so you can reuse it](https://github.com/kelvinburke/sciris/commit/f57c83a420040a390f0f3bd5b08dd5137067439d)

^^ This fixes a bug: When doing `sc.equal(A, B, skip={'ids':['id1']})` the `skip` kwarg gets correctly passed to iterate over `A` but this clears the dictionary because `skip_ids = scu.tolist(skip.pop('ids', None))` , so the `skip` dictionary is now empty to iterate over `B`.
The fix is just to do `skip = scu.dcp(skip)`

[IterObj add skip_keys](https://github.com/kelvinburke/sciris/commit/c99d58ff515a77b343cd1c445a9fb2cd5535a23c)
Simple enhancement - allows skipping over keys, these can be generic eg. 
`skip={'keys':[0]}` allows skipping over the 0th object in arrays, lists and tuples.

[Add set_to_obj() (based off IterObj.setitem()) and adjust `setneste`…](https://github.com/kelvinburke/sciris/commit/be6ab3de554f3e4dc3c51ceea5f66e2ad6000e66)
Another simple enhancement. Allows setting values to generic objects.
My use-case is extracting result arrays from `at.Result` to be saved. Then they later be loaded and applied to another `at.Result` object.