### PR TITLE
Fix for matplotlib 3.10

### DIFF
--- a/sciris/sc_plotting.py
+++ b/sciris/sc_plotting.py
@@ -1588,6 +1588,7 @@ def separatelegend(ax=None, handles=None, labels=None, reverse=False, figsetting
     for h in handles:
         h2 = sc.cp(h)
         h2.axes = None
+        h2._parent_figure = None
         h2.figure = None
         handles2.append(h2)
 


### PR DESCRIPTION
matplotlib 3.10 now checks `._parent_figure` when setting `.figure` so it's necessary to set the parent figure to `None` before trying to set the `figure` to `None`