### PR TITLE
Findnearest tweak

### DIFF
--- a/sciris/sc_math.py
+++ b/sciris/sc_math.py
@@ -205,7 +205,7 @@ def findnearest(series=None, value=None):
         sc.findnearest([0,2,4,6,8,10], [3, 4, 5]) # returns array([1, 2, 2])
     """
     series = sc.toarray(series)
-    if sc.isnumber(value):
+    if not sc.isiterable(value):
         output = np.argmin(abs(series-value))
     else:
         output = []

--- a/sciris/sc_plotting.py
+++ b/sciris/sc_plotting.py
@@ -1588,6 +1588,7 @@ def separatelegend(ax=None, handles=None, labels=None, reverse=False, figsetting
     for h in handles:
         h2 = sc.cp(h)
         h2.axes = None
+        h2._parent_figure = None
         h2.figure = None
         handles2.append(h2)
 


### PR DESCRIPTION
Allow findnearest to work with other non-number scalar objects (e.g., ss.Date) that implement the requisite operators but otherwise return False for `isnumber()` 