### PR TITLE
Fix setnested bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ All major updates to Sciris are documented here.
 
 By import convention, components of the Sciris library are listed beginning with ``sc.``, e.g. ``sc.odict()``.
 
+Version 3.2.3 (2025-07-XX)
+--------------------------
+#. Fixed a bug with :func:`sc.setnested() <sc_nested.setnested>` when attempting to write values with missing intermediate keys.
 
 Version 3.2.2 (2025-07-01)
 --------------------------

--- a/sciris/sc_nested.py
+++ b/sciris/sc_nested.py
@@ -255,9 +255,14 @@ def setnested(nested, keylist, value, force=True):
     if not isinstance(keylist, (list, tuple)): # Be careful not to wrap tuples in lists
         keylist = sc.tolist(keylist)
     parentkeys = keylist[:-1]
-    if force and parentkeys:
-        makenested(nested, parentkeys, overwrite=False)
-    currentlevel = getnested(nested, parentkeys)
+    try:
+        currentlevel = getnested(nested, parentkeys)
+    except KeyError as e:
+        if force:
+            currentlevel = nested.__class__()
+            makenested(nested, parentkeys, value=currentlevel, overwrite=False)
+        else:
+            raise e
     set_in_obj(currentlevel, keylist[-1], value)
     return nested # Return object, but note that it's modified in place
 

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -297,6 +297,10 @@ def test_equal():
 
     return out
 
+def test_setnested():
+    d = {}
+    sc.setnested(d,['a','b'],'c')
+    assert d['a']['b'] == 'c'
 
 #%% Run as a script
 if __name__ == '__main__':


### PR DESCRIPTION
Fix a bug with 

```python
d = {}
sc.setnested(d,['a','b'],'c')
```

not working (this is now also covered by a test)